### PR TITLE
Fix minor bugs with hair and SFX

### DIFF
--- a/celeste.c
+++ b/celeste.c
@@ -859,10 +859,10 @@ static void PLAYER_update(OBJ* this) {
 			}
 			if (this->spd.x!=0) {
 				this->dash_accel.y*=0.70710678118f;
-			} else if (dash && this->djump<=0) {
-				psfx(9);
-				init_object(OBJ_SMOKE,this->x,this->y);
 			}
+		} else if (dash && this->djump<=0) {
+			psfx(9);
+			init_object(OBJ_SMOKE,this->x,this->y);
 		}
 	}
    
@@ -925,13 +925,14 @@ static void draw_hair(OBJ* obj, int facing) {
 	float last_y=obj->y+(P8btn(k_down) ? 4 : 3);
 	HAIR* h;
 	int i = 0;
-	while (!(h = &obj->hair[i++])->isLast) {
+	do {
+		h = &obj->hair[i++];
 		h->x+=(last_x-h->x)/1.5;
 		h->y+=(last_y+0.5-h->y)/1.5;
 		P8circfill(h->x,h->y,h->size,8);
 		last_x=h->x;
 		last_y=h->y;
-	}
+	} while (!h->isLast);
 }
 
 static void unset_hair_color() {


### PR DESCRIPTION
Hi! I am porting ccleste to other platforms with raylib, and have spotted issues with simple fixes. Details are as follows.

**(1) SFX 9 should be played on triggering an invalid dash**

This is caused by mistranslation of a block at line 279 of the original code.

```lua
    if this.spd.x!=0 then
     this.dash_accel.y*=0.70710678118
    end
   elseif dash and this.djump<=0 then
    psfx(9)
    init_object(smoke,this.x,this.y)
   end
```

The `elseif` is not paired with the `if` (as there is already an `end`); it is for the outer one. This can be **very** misleading if tabstop is set to 2 :rofl:

**(2) The last circle for the character's hair is not drawn**

The original game draws 5 circles, but ccleste draws only 4.

There are similar structures (looping with `while (!isLast)` to emulate `foreach` in the original Lua code) for clouds and particles. This issue does not affect clouds, as only the 25th cloud in the stage will disappear, and there are not as many clouds in-game; but for particles I have not looked into more details. Maybe I will update the commit later.